### PR TITLE
solve xmake version problem

### DIFF
--- a/tooth.json
+++ b/tooth.json
@@ -13,7 +13,7 @@
     },
     "asset_url": "https://github.com/OEOTYAN/BedrockServerClientInterface/releases/download/v$(version)/BedrockServerClientInterface-windows-x64.zip",
     "prerequisites": {
-        "github.com/LiteLDev/LeviLamina": ">=1.0.0"
+        "github.com/LiteLDev/LeviLamina": ">=1.3.4"
     },
     "files": {
         "place": [

--- a/xmake.lua
+++ b/xmake.lua
@@ -2,8 +2,8 @@ add_rules("mode.release")
 
 add_repositories("liteldev-repo https://github.com/LiteLDev/xmake-repo.git")
 
-add_requires("levilamina 1.1.0-rc.1")
-add_requires("levibuildscript 0.3.0")
+add_requires("levilamina 1.3.4")
+add_requires("levibuildscript")
 
 if not has_config("vs_runtime") then
     set_runtimes("MD")


### PR DESCRIPTION
## What does this PR do?
用于更新xmake.lua中的ll版本


## Which issues does this PR resolve?
ll 1.3.4+需要使用xmake 3.0.0+，这会导致bsci作为前置时出现无法编译ll 1.1.0-rc.2的问题，因此需要将xmake.lua中的ll版本提高至1.3.4以上


## Checklist before merging

Thank you for your contribution to the repository. 
Before submitting this PR, please make sure:

- [ ] Your code builds clean without any errors or warnings
- [ ] Your code follows [LeviLamina C++ Style Guide](https://github.com/LiteLDev/LeviLamina/wiki/CPP-Style-Guide)
- [ ] You have tested all functions
- [ ] You have not used code without license
- [ ] You have added statement for third-party code
